### PR TITLE
updating point threshold from 150 to 300

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 nbactions.xml
 nb-configuration.xml
 nbproject/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ That's it, lmao.
 - Mine essence until notified to stop.
 - Craft runes that are in the tier you want. Red tier is recommended as they give the most points for a cell. 
 - Place cell on a barrier after you've crafted.
-- Repeat as needed until above 150 points total. 
+- Repeat as needed until above 300 points total.
 - Go back to mining essence.
 
 Enjoy the 25k to 40k xp/hr (depending on your RC level) 

--- a/src/main/java/com/zom/AFKGuardiansConfig.java
+++ b/src/main/java/com/zom/AFKGuardiansConfig.java
@@ -53,8 +53,8 @@ public interface AFKGuardiansConfig extends Config
 
 	@ConfigItem(
 		keyName = "hideInfoBox",
-		name = "Hide info box when above 150",
-		description = "Hide the info box when over 150 points",
+		name = "Hide info box when above 300",
+		description = "Hide the info box when over 300 points",
 		position = 4
 	)
 	default boolean hideInfoBox()
@@ -75,8 +75,8 @@ public interface AFKGuardiansConfig extends Config
 
 	@ConfigItem(
 		keyName = "additionalNotify",
-		name = "Notify when below 150, again.",
-		description = "Notifies when specific color is up & below 150",
+		name = "Notify when below 300, again.",
+		description = "Notifies when specific color is up & below 300",
 		position = 6
 	)
 	default boolean additionalNotify()
@@ -87,8 +87,8 @@ public interface AFKGuardiansConfig extends Config
 	@Range(min = -1, max = 99)
 	@ConfigItem(
 		keyName = "additionalPercent",
-		name = "Notify when below 150 at a certain %",
-		description = "Notifies when at a specific % when color is up & below 150",
+		name = "Notify when below 300 at a certain %",
+		description = "Notifies when at a specific % when color is up & below 300",
 		position = 7
 	)
 	default int additionalPercent()
@@ -109,8 +109,8 @@ public interface AFKGuardiansConfig extends Config
 
 	@ConfigItem(
 			keyName = "portalNotify",
-			name = "Notify on portal when below 150",
-			description = "Send notification when a portal spawns and you are below 150",
+			name = "Notify on portal when below 300",
+			description = "Send notification when a portal spawns and you are below 300",
 			position = 9
 	)
 	default boolean portalNotify() { return false; }

--- a/src/main/java/com/zom/AFKGuardiansPlugin.java
+++ b/src/main/java/com/zom/AFKGuardiansPlugin.java
@@ -177,7 +177,7 @@ public class AFKGuardiansPlugin extends Plugin
 		}
 
 		// allow for second notification
-		if (activeGuardians.size() == 0 && getSum() < 150 && alwaysNotify)
+		if (activeGuardians.size() == 0 && getSum() < 300 && alwaysNotify)
 		{
 			hasBeenNotified = false;
 		}
@@ -206,7 +206,7 @@ public class AFKGuardiansPlugin extends Plugin
 		}
 
 		// send notification
-		if (activeGuardians.size() > 0 && !hasBeenNotified && getSum() < 150 && !hasGuardianStone() && postAFK && (!hasCell() || alertWithCell))
+		if (activeGuardians.size() > 0 && !hasBeenNotified && getSum() < 300 && !hasGuardianStone() && postAFK && (!hasCell() || alertWithCell))
 		{
 			notifier.notify("Go craft runes at available altar!");
 			hasBeenNotified = true;
@@ -260,7 +260,7 @@ public class AFKGuardiansPlugin extends Plugin
 		if (gameObject.getId() == PORTAL)
 		{
 			if (config.portalNotify()
-					&& getSum() < 150
+					&& getSum() < 300
 					&& checkInMinigame()
 					&& (minPortalNotificationTime == null || Instant.now().isAfter(minPortalNotificationTime)))
 			{
@@ -278,12 +278,12 @@ public class AFKGuardiansPlugin extends Plugin
 		setCurrentElementalRewardPoints(client.getVarbitValue(13686));
 		setCurrentCatalyticRewardPoints(client.getVarbitValue(13685));
 
-		if (getSum() < 150 && alwaysNotify)
+		if (getSum() < 300 && alwaysNotify)
 		{
 			hasBeenNotified = false;
 		}
 
-		if (getSum() >= 150 && config.hideInfoBox())
+		if (getSum() >= 300 && config.hideInfoBox())
 		{
 			disableInfoBox();
 		}
@@ -322,13 +322,13 @@ public class AFKGuardiansPlugin extends Plugin
 				@Override
 				public String getText()
 				{
-					return getSum() + "/150";
+					return getSum() + "/300";
 				}
 
 				@Override
 				public Color getTextColor()
 				{
-					return getSum() < 150 ? Color.RED : Color.GREEN;
+					return getSum() < 300 ? Color.RED : Color.GREEN;
 				}
 			};
 			infoBoxManager.addInfoBox(goodToAFKInfoBox);


### PR DESCRIPTION
Even at 300 point thresholds, this plugin provides a lot of value. If players only use portals, you can get to 300 points around the 60% mark. If you do 1 portal and 1 mined inv, you can get there around 30-40%. And if you start the round in the portal mine, you can do it even faster!